### PR TITLE
Adding CI/CD github actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.pytest_cache/
+__pycache__/
+.env

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -1,7 +1,7 @@
 name: Deploy to App Runner - Image based # Name of the workflow
-on: [push]
-  # push:
-  #   branches: [ main ]
+on:
+  push:
+    branches: [ main ]
 
 
 jobs:
@@ -26,6 +26,7 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
+      # this is the only step needed, appRunner configured with terraform
       - name: Build, tag, and push image to Amazon ECR
         id: build-image
         env:
@@ -36,17 +37,3 @@ jobs:
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:latest"
-
-      - name: Deploy to App Runner
-        id: deploy-apprunner
-        uses: awslabs/amazon-app-runner-deploy@main
-        with:
-          service: cdmx-metrobus-backendInfo
-          image: ${{ steps.build-image.outputs.image }}
-          # testing if 
-          # access-role-arn: ${{ secrets.ROLE_ARN }}
-          # region: ${{ secrets.AWS_REGION }}
-          wait-for-service-stability: true
-
-      - name: App Runner output
-        run: echo "App runner output ${{ steps.deploy-apprunner.outputs.service-id }}"

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -30,7 +30,7 @@ jobs:
         id: build-image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: keanrawr
+          ECR_REPOSITORY: cdmx-mb-backend
           IMAGE_TAG: ${{ github.sha }}
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -1,0 +1,52 @@
+name: Deploy to App Runner - Image based # Name of the workflow
+on: [push]
+  # push:
+  #   branches: [ main ]
+
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Configure AWS credentials
+        id: aws-credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: keanrawr
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:latest"
+
+      - name: Deploy to App Runner
+        id: deploy-apprunner
+        uses: awslabs/amazon-app-runner-deploy@main
+        with:
+          service: cdmx-metrobus-backendInfo
+          image: ${{ steps.build-image.outputs.image }}
+          # testing if 
+          # access-role-arn: ${{ secrets.ROLE_ARN }}
+          # region: ${{ secrets.AWS_REGION }}
+          wait-for-service-stability: true
+
+      - name: App Runner output
+        run: echo "App runner output ${{ steps.deploy-apprunner.outputs.service-id }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . /app
 
 RUN pip install pip --upgrade
 RUN pip install poetry
-RUN poetry install
+RUN poetry install --without dev
 # TODO: Use a non root user
 
 CMD poetry run uvicorn app.main:app --host 0.0.0.0


### PR DESCRIPTION
Introducing the following changes:

- Adding CI/CD pipeline to deploy to aws appRunner
- Modifying Dockerfile to omit installing dev dependencies
- Adding `.dockerignore` file to avoid building a bloated image with dev files

The appRunner service and the ECR repository, have been configured in the iac repo, this repo isn't backed in github, but the appRunner service was configured to autodeploy every time a new version of the image is pushed to the ECR repository.